### PR TITLE
Chore/model exists endpoints

### DIFF
--- a/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.controller.ts
+++ b/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Param, Post, Get, Put, Delete, NotFoundException } from '@nestjs/common';
+import { Body, Controller, Param, Post, Get, Put, Delete, NotFoundException, UseInterceptors, ClassSerializerInterceptor } from '@nestjs/common';
 import { DeepchatProxyService } from './deepchat-proxy.service';
 import { DeepchatProxy } from './deepchat-proxy.schema';
 import { ProxyCompletion } from './dtos/proxy-completion.dto';
 import { CompletionResponse } from 'src/litellm/dtos/litellm.dto';
 
 @Controller('deepchat-proxy')
+@UseInterceptors(ClassSerializerInterceptor)
 export class DeepchatProxyController {
   constructor(private readonly deepchatProxyService: DeepchatProxyService) {}
 

--- a/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.controller.ts
+++ b/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Param, Post, Get, Put, Delete, NotFoundException, UseInterceptors, ClassSerializerInterceptor } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  Get,
+  Put,
+  Delete,
+  NotFoundException,
+  UseInterceptors,
+  ClassSerializerInterceptor
+} from '@nestjs/common';
 import { DeepchatProxyService } from './deepchat-proxy.service';
 import { DeepchatProxy } from './deepchat-proxy.schema';
 import { ProxyCompletion } from './dtos/proxy-completion.dto';

--- a/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.schema.ts
+++ b/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.schema.ts
@@ -1,4 +1,5 @@
 import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import { Exclude } from 'class-transformer';
 
 @Schema()
 export class DeepchatProxy {
@@ -11,6 +12,7 @@ export class DeepchatProxy {
   url: string;
 
   // API KEY to pass as header to LiteLLM
+  @Exclude()
   @Prop({ required: true })
   apiKey: string;
 }

--- a/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.service.ts
+++ b/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.service.ts
@@ -13,11 +13,18 @@ export class DeepchatProxyService {
   ) {}
 
   async get(id: string): Promise<DeepchatProxy | null> {
-    return this.deepChatProxyModel.findOne({ _id: id });
+    let modelData = this.deepChatProxyModel.findOne({ _id: id });
+    // remove the apiKey from the response
+    modelData = modelData.select('-apiKey');
+    return modelData;
   }
 
   async getAll(): Promise<DeepchatProxy[]> {
-    return this.deepChatProxyModel.find();
+    // model data without the apiKey
+    let modelData = this.deepChatProxyModel.find();
+    // remove the apiKey from all
+    modelData = modelData.select('-apiKey');
+    return modelData;
   }
 
   async create(mapping: DeepchatProxy): Promise<DeepchatProxy> {

--- a/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.service.ts
+++ b/packages/helper-backend/src/deepchat-proxy/deepchat-proxy.service.ts
@@ -3,6 +3,7 @@ import { DeepchatProxy, DeepchatProxyDocument } from './deepchat-proxy.schema';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { LiteLLMService } from 'src/litellm/litellm.service';
+import { plainToInstance } from 'class-transformer';
 
 @Injectable()
 export class DeepchatProxyService {
@@ -13,29 +14,27 @@ export class DeepchatProxyService {
   ) {}
 
   async get(id: string): Promise<DeepchatProxy | null> {
-    let modelData = this.deepChatProxyModel.findOne({ _id: id });
-    // remove the apiKey from the response
-    modelData = modelData.select('-apiKey');
-    return modelData;
+    let result = await this.deepChatProxyModel.findOne({ _id: id }).lean().exec();
+    return plainToInstance(DeepchatProxy, result);
   }
 
   async getAll(): Promise<DeepchatProxy[]> {
     // model data without the apiKey
-    let modelData = this.deepChatProxyModel.find();
-    // remove the apiKey from all
-    modelData = modelData.select('-apiKey');
-    return modelData;
+    const results = await this.deepChatProxyModel.find().lean().exec();
+    return plainToInstance(DeepchatProxy, results);
   }
 
   async create(mapping: DeepchatProxy): Promise<DeepchatProxy> {
-    return await this.deepChatProxyModel.create(mapping);
+    const result = await this.deepChatProxyModel.create(mapping);
+    return plainToInstance(DeepchatProxy, result);
   }
 
   async update(id: string, mapping: DeepchatProxy): Promise<DeepchatProxy | null> {
-    return await this.deepChatProxyModel.findOneAndUpdate({ _id: id }, mapping, {
+    const result = await this.deepChatProxyModel.findOneAndUpdate({ _id: id }, mapping, {
       new: true,
       upsert: true
     });
+    return plainToInstance(DeepchatProxy, result);
   }
 
   async delete(model: string): Promise<void> {


### PR DESCRIPTION
Updated security by removing api keys in responses.
Didn't need to add the exists end point, can just get model with id instead now.