### PR TITLE
security: bind staging Postgres 5432 to localhost only

### DIFF
--- a/deploy/portainer/docker-compose.yml
+++ b/deploy/portainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     container_name: portainer-PostgreSQL
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - portainer-postgres-data:/var/lib/postgresql/data
       - portainer-postgres-init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Postgres in the staging compose was published to 0.0.0.0:5432, making the database reachable from the public internet to anyone with the password. Prod's compose already has no ports directive on Postgres, so this only applies to staging.