### PR TITLE
Ragflow Startup Config Edits

### DIFF
--- a/deploy/local/docker-compose.yml
+++ b/deploy/local/docker-compose.yml
@@ -223,7 +223,6 @@ services:
     env_file: "config/.env.ragflow"
     environment:
       - node.name=ragflow-es
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-ragflow_elastic_pass}
       - bootstrap.memory_lock=false
       - discovery.type=single-node
       - xpack.security.enabled=true

--- a/deploy/local/postgres-init/01-create-n8n-db.sql
+++ b/deploy/local/postgres-init/01-create-n8n-db.sql
@@ -1,9 +1,5 @@
 -- Create n8n database if it doesn't exist
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'n8n') THEN
-        CREATE DATABASE n8n;
-    END IF;
-END
-$$;
+SELECT 'CREATE DATABASE n8n'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'n8n')
+\gexec
 

--- a/deploy/local/postgres-init/02-create-ragflow-db.sql
+++ b/deploy/local/postgres-init/02-create-ragflow-db.sql
@@ -1,9 +1,6 @@
 -- Create rag_flow database if it doesn't exist
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'rag_flow') THEN
-        CREATE DATABASE rag_flow;
-    END IF;
-END
-$$;
+SELECT 'CREATE DATABASE rag_flow'
+WHERE NOT EXISTS (
+    SELECT FROM pg_database WHERE datname = 'rag_flow'
+)\gexec
 

--- a/deploy/local/ragflow/nginx.conf
+++ b/deploy/local/ragflow/nginx.conf
@@ -12,13 +12,13 @@ server {
     index index.html;
 
     # API proxy
-    location /v1/ {
-        proxy_pass http://127.0.0.1:9380/v1/;
+    location /api/v1/ {
+        proxy_pass http://127.0.0.1:9380/api/v1/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
+
         # Increase upload size for API endpoints as well
         client_max_body_size 100M;
     }


### PR DESCRIPTION
I am now able to create chats, search apps, etc. after the following edits.

- Removing the duplicate password for elastic-search as in my case it would set ragflow_elastic_pass as the default password because it did not access my .env.ragflow file when setting the password. Removing this line allows my elastic search environment password to be used instead of clashing with the default password. I think this is okay to do only because having a default password from a public repository is only slightly better than having no password if someone never created the env file when initializing Ragflow.

- Editing 01-create-n8n-db.sql and 02-create-ragflow-db.sql so that the databases are created when the files are run. Seems like there was some kind of hallucination before? Not entirely sure.

- Updating the ngnix.conf file to correct for a different actual location than what was previously listed as the route (api/v1/... instead of v1/...)